### PR TITLE
Fix rnd() snippet

### DIFF
--- a/snippets/language-aoe2-rms.cson
+++ b/snippets/language-aoe2-rms.cson
@@ -166,4 +166,4 @@
 
   'Random Number':
     'prefix': 'rnd'
-    'body': 'rnd(${1:min}, ${2:max})$3'
+    'body': 'rnd(${1:min},${2:max})$3'


### PR DESCRIPTION
rnd() expressions may not contain spaces.